### PR TITLE
Updated the extensions spec with the new discover routes

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -52,7 +52,7 @@ As of current, ```_oci``` and ```_ext``` are considered as reserved namespaces a
 
 ## Filename
 
-Extension definitions SHOULD be placed under `./ext/`. Extension files
+Extension definitions SHOULD be placed under `./ext/` in the specification repository. Extension files
 SHOULD follow the `ext-$ns-$name.md`. Refer [ext.md](./ext.md) for more details.
 
 ## Detail

--- a/ext/README.md
+++ b/ext/README.md
@@ -47,6 +47,9 @@ can be access under a repository.
 GET /v2/<name>/_<ns>/<ext>/<component>[?<key>=<value>&...]
 ```
 
+### Reserved Namespaces
+As of current, ```_oci``` and ```_ext``` are considered as reserved namespaces and cannot be used by other extensions.
+
 ## Filename
 
 Extension definitions SHOULD be placed under `./ext/`. Extension files

--- a/ext/README.md
+++ b/ext/README.md
@@ -10,16 +10,16 @@ be emulated for all extensions.
 
 ## Table
 
-_notice_: All new `./ext/ext-$name.md` docs MUST be added to this table.
+_notice_: All new `./ext/ext-$ns-$name.md` docs MUST be added to this table.
 
-| `$name`                  | Summary                                              |
+| `$ns-$name`                  | Summary                                              |
 |:------------------------:|:----------------------------------------------------:|
 | [ext](./ext.md)          | Extensions discovering extensions on registry server |
 
 ## Name
 
 Extension names MUST be unique. Extensions are  specified by
-`namespace` aligning with the project, followed by the `extension` provided by the project and last by by the `component`. This constitues the URI segments
+`namespace` aligning with the project, followed by the `extension` provided by the project and last by by the `component`. This constitutes the URI segments
 of the extension endpoint. Additional options may be passed as parameters to the endpoint.
 
 ```http
@@ -49,8 +49,8 @@ GET /v2/<name>/_<ns>/<ext>/<component>[?<key>=<value>&...]
 
 ## Filename
 
-Extention definitions SHOULD be placed under `./ext/`. Extension files
-SHOULD follow the `ext-$name.md`. Refer [ext.md](./ext.md) for more details.
+Extension definitions SHOULD be placed under `./ext/`. Extension files
+SHOULD follow the `ext-$ns-$name.md`. Refer [ext.md](./ext.md) for more details.
 
 ## Detail
 

--- a/ext/ext.md
+++ b/ext/ext.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This base extension is used to discover and return an array of extensions.
+This base extension namespace is used to discover and return an array of extensions.
 
 ## Reference Explanation
 
@@ -12,13 +12,13 @@ extensions.
 Registry level extensions may be discovered with a standard GET as follows.
 
 ```HTTP
-    GET /v2/_ext/
+    GET /v2/_ext/discover
 ```
 
 Repository level extensions may be discovered with a standard GET as follows.
 
 ```HTTP
-    GET /v2/{name}/_ext/
+    GET /v2/{name}/_ext/discover
 ```
 
 The base extension returns an array of supported extensions with details of the
@@ -31,14 +31,16 @@ Content-Type: application/json
 
 {
     "extensions: [
-        "_<ns>/<ext>/<component>",
+        {
+            "name": "_<ns>/<ext>/<component>"
+        },
     ]    
 }
 ```
 
 ### *Extensions* Property Descriptions
 
-- **`extensions`** *array of strings*
+- **`extensions`** *array of extension objects with properties like `name`*
 
     This REQUIRED property contains a list of supported extension endpoints.
 


### PR DESCRIPTION
Updated the extensions spec as per the comments on the PR . The major changes are 
- Changed the discovery API route to /v2/_ext/discover (https://github.com/opencontainers/distribution-spec/pull/111/files/a9c3cdc9e554894edc30dfea5e808406244a93be#r728376000 )
- Changed the extension response to contain an array of objects rather than strings (https://github.com/opencontainers/distribution-spec/pull/111/files/a9c3cdc9e554894edc30dfea5e808406244a93be#r728380290)

Signed-off-by: Tejaswini Duggaraju <naduggar@microsoft.com>